### PR TITLE
migrate librsvg to librsvg-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "texvcinfo": "^0.5.3"
   },
   "optionalDependencies": {
-    "librsvg": "^0.7.0",
+    "librsvg-prebuilt": "^0.7.0",
     "swagger-ui": "git+https://github.com/wikimedia/swagger-ui#master"
   },
   "devDependencies": {


### PR DESCRIPTION
Per https://github.com/2gis/node-rsvg/pull/17#issuecomment-492086896, node-rsvg ("librsvg") is no longer maintained. That package also does not compile on macOS as noted in the linked PR. librsvg-prebuilt has prebuilt binaries for all major platforms.